### PR TITLE
Cherry pick some additional scripts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+spdk (24.09-1.1) UNRELEASED; urgency=medium
+
+  * Add scripts
+
+ -- Brian Meagher <brian.meagher@truenas.com>  Wed, 25 Jun 2025 19:28:14 +0100
+
 spdk (24.09-1) UNRELEASED; urgency=medium
 
   * Initial version of TrueNAS SPDK based on upstream

--- a/debian/truenas-spdk.install
+++ b/debian/truenas-spdk.install
@@ -4,7 +4,10 @@ usr/bin/spdk_nvme_identify opt/spdk/usr/bin
 scripts/common.sh opt/spdk/scripts
 scripts/rpc.py opt/spdk/scripts
 scripts/setup.sh opt/spdk/scripts
+scripts/spdk-gpt.py opt/spdk/scripts
 include/spdk/pci_ids.h  opt/spdk/include/spdk
+dpdk/usertools/dpdk-devbind.py opt/spdk/scripts
+dpdk/usertools/dpdk-hugepages.py opt/spdk/scripts
 dpdk/license/* usr/share/doc/truenas-spdk/dpdk/license
 intel-ipsec-mb/LICENSE usr/share/doc/truenas-spdk/intel-ipsec-mb
 isa-l/LICENSE usr/share/doc/truenas-spdk/isa-l


### PR DESCRIPTION
Add some additional scripts to `/opt/spdk/scripts`:
- `spdk-gpt.py`
- `dpdk-devbind.py`
- `dpdk-hugepages.py`

The first prevents the setup.sh from generating errors, and the other two are useful when debugging DPDK issues (e.g. device binding).