### PR TITLE
NAS-140500 / 26.0.0-BETA.1 / Add ibverbs-providers runtime dependency (by bmeagherix)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+spdk (26.01-1.1) UNRELEASED; urgency=medium
+
+  * Add ibverbs-providers runtime dependency
+
+ -- Brian Meagher <brian.meagher@truenas.com>  Wed, 01 Apr 2026 13:51:54 -0700
+
 spdk (26.01-1) UNRELEASED; urgency=medium
 
   * Upgrade SPDK from v25.05.x to v26.01.x

--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Depends:
  libarchive13,
  libnuma1,
  libibverbs1,
+ ibverbs-providers,
  librdmacm1,
  liburing2,
  libjson-c5,


### PR DESCRIPTION
Without it, `libibverbs1` cannot open RDMA devices, causing `rdma_create_event_channel()` to fail with `ENODEV`.

Original PR: https://github.com/truenas/truenas_spdk/pull/7
